### PR TITLE
ec2-ssh script is not sh-compatible

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #/ Usage: ec2-ssh <instance-name>
 #/ Open ssh connection to EC2 instance where tag:Name=<instance-name>
 #/ For list of instance, run ec2-host without any paramteres


### PR DESCRIPTION
When trying to run ec2-ssh, I consistently get the error:

```
apetresc@bumblebee:~$ ec2-ssh tomcat1
/home/apetresc/.virtualenv/twitsprout/bin/ec2-ssh: 16: Syntax error: "(" unexpected
```

The problem is that line 16 uses `declare`, a feature that is not part of plain old standard `sh`:

```
IFS="@"; declare -a hostparts=($1)
```

I fixed this by hinting `/bin/bash` instead of `/bin/sh` and now it works great. Here's the pull request :)
