### PR TITLE
Added a -i parameter to ec2-ssh

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,7 +1,7 @@
 #!/bin/sh
-#/ Usage: ec2-ssh <instance-name>
+#/ Usage: ec2-ssh [-i private-key-file] <instance-name>
 #/ Open ssh connection to EC2 instance where tag:Name=<instance-name>
-#/ For list of instance, run ec2-host without any paramteres
+#/ For a list of instances, run ec2-host without any parameters
 
 set -e
 
@@ -12,14 +12,23 @@ test $# -eq 0 -o $(expr "$*" : ".*--help") \
     exit
 }
 
+# Check if -k is given
+if test "$1" = "-i"; then
+  privatekeyfile="$2"
+  hostchunk="$3"
+else
+  privatekeyfile=""
+  hostchunk="$1"
+fi
+
 # support user@instance-name format
-IFS="@"; declare -a hostparts=($1) 
+IFS="@"; declare -a hostparts=($hostchunk)
 
 inst="${hostparts[1]}"
 user="${hostparts[0]}"
 
 if test -z "$inst"; then
-	inst="$1"
+	inst="$hostchunk"
 	user="ubuntu"
 fi
 
@@ -28,4 +37,8 @@ host=$(ec2-host $inst)
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime
-test -n "$host" && exec sh -c "ssh $user@$host ${@:2}"
+if test -n "$privatekeyfile"; then
+  test -n "$host" && exec sh -c "ssh -i $privatekeyfile $user@$host ${@:4}"
+else
+  test -n "$host" && exec sh -c "ssh $user@$host ${@:2}"
+fi


### PR DESCRIPTION
This allows ec2-ssh to be used by people still using the default identity file from their EC2 Keypair. The best way to do this is:

```
alias ec2-ssh='ec2-ssh -i ~/.ssh/private.pem'
```
