### PR TITLE
Added support for specifying the tag to search on

### DIFF
--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -13,25 +13,26 @@ _ec2 = None
 
 
 def short_usage():
-    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [NAME]
+    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [-t TAG] [NAME]
     ec2-host django8 => ec2-53-19-113-121.compute-1.amazonaws.com
 Try `ssh-distillery --help' for more information."""
 
 
 def full_usage():
-    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [NAME]
+    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [-t TAG] [NAME]
 Prints server host name.
 
       --help                 display this help and exit
   -k, --aws-key KEY          Amazon EC2 Key, defaults to ENV[AWS_ACCESS_KEY_ID]
   -s, --aws-secret SECRET    Amazon EC2 Secret, defaults to ENV[AWS_SECRET_ACCESS_KEY]
-  -r, --region REGION        Amazon EC2 Region, defaults to us-east-1 or ENV[AWS_EC2_REGION]"""
+  -r, --region REGION        Amazon EC2 Region, defaults to us-east-1 or ENV[AWS_EC2_REGION]
+  -t, --tag TAG              Tag name for searching, defaults to 'Name'"""
 
 
-def list_instances():
+def list_instances(tag="Name"):
   instance_pairs = []
   for instance in ec2_instances():
-      instance_name = instance.tags.get("Name")
+      instance_name = instance.tags.get(tag)
       if instance.public_dns_name:
           pair = (instance_name, instance.public_dns_name)
           instance_pairs.append(pair)
@@ -39,12 +40,12 @@ def list_instances():
       print "%s\t%s" % pair
 
 
-def print_host(name):
-    filters = {'tag:Name': name}
+def print_host(value, tag="Name"):
+    filters = {'tag:%s' % tag: value}
     instances = ec2_instances(filters=filters)
 
     if len(instances) == 0:
-        print >>stderr, 'Unable to match instance named "%s"' % name
+        print >>stderr, 'Unable to match instance named "%s"' % value
         short_usage()
         sys.exit(1)
 
@@ -63,8 +64,8 @@ def ec2_instances(**kwargs):
 
 def main(argv):
     try:
-        opts, args = getopt.getopt(argv, "hLk:s:r:",
-                                         ["help", "aws-key", "aws-secret", "region"])
+        opts, args = getopt.getopt(argv, "hLk:s:r:t:",
+                                         ["help", "aws-key", "aws-secret", "region", "tag"])
     except getopt.GetoptError, err:
         print >>sys.stderr, err
         short_usage()
@@ -73,17 +74,20 @@ def main(argv):
     aws_key = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
     region = os.environ.get("AWS_EC2_REGION")
+    tag = "Name"
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
             full_usage()
             sys.exit()
-        elif opt in("-k", "--aws-key"):
+        elif opt in ("-k", "--aws-key"):
             aws_key = arg
-        elif opt in("-s", "--aws-secret"):
+        elif opt in ("-s", "--aws-secret"):
             aws_secret = arg
-        elif opt in("-r", "--region"):
+        elif opt in ("-r", "--region"):
             region = arg
+        elif opt in ("-t", "--tag"):
+            tag = arg
 
     if not aws_key or not aws_secret:
         if not aws_key:
@@ -99,21 +103,23 @@ def main(argv):
         short_usage()
         sys.exit(2)
 
-    region = region and boto.ec2.get_region(region, aws_access_key_id=aws_key, aws_secret_access_key=aws_secret)
+    region = region and boto.ec2.get_region(region, 
+                                            aws_access_key_id=aws_key, 
+                                            aws_secret_access_key=aws_secret)
 
     global _ec2
     _ec2 = boto.ec2.connection.EC2Connection(aws_key, aws_secret, region=region)
 
     argc = len(args)
     if argc == 0:
-        list_instances()
+        list_instances(tag)
         sys.exit()
     else:
         if argc > 1:
             print >>stderr, "Warning: more than one name given"
 
-        name = args[0]
-        print_host(name)
+        value = args[0]
+        print_host(value, tag)
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -6,7 +6,7 @@ import getopt
 
 from sys import stderr
 
-import boto
+import boto.ec2
 
 
 _ec2 = None
@@ -62,8 +62,8 @@ def ec2_instances(**kwargs):
 
 def main(argv):
     try:
-        opts, args = getopt.getopt(argv, "hLk:s:",
-                                         ["help", "aws-key", "aws-secret"])
+        opts, args = getopt.getopt(argv, "hLk:s:r:",
+                                         ["help", "aws-key", "aws-secret", "region"])
     except getopt.GetoptError, err:
         print >>sys.stderr, err
         short_usage()
@@ -71,6 +71,7 @@ def main(argv):
 
     aws_key = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    region = None
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
@@ -80,6 +81,8 @@ def main(argv):
             aws_key = arg
         elif opt in("-s", "--aws-secret"):
             aws_secret = arg
+        elif opt in("-r", "--region"):
+            region = arg
 
     if not aws_key or not aws_secret:
         if not aws_key:
@@ -95,8 +98,10 @@ def main(argv):
         short_usage()
         sys.exit(2)
 
+    region = region and boto.ec2.get_region(region, aws_access_key_id=aws_key, aws_secret_access_key=aws_secret)
+
     global _ec2
-    _ec2 = boto.connect_ec2(aws_key, aws_secret)
+    _ec2 = boto.ec2.connection.EC2Connection(aws_key, aws_secret, region=region)
 
     argc = len(args)
     if argc == 0:

--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -25,7 +25,7 @@ Prints server host name.
       --help                 display this help and exit
   -k, --aws-key KEY          Amazon EC2 Key, defaults to ENV[AWS_ACCESS_KEY_ID]
   -s, --aws-secret SECRET    Amazon EC2 Secret, defaults to ENV[AWS_SECRET_ACCESS_KEY]
-  -r, --region REGION        Amazon EC2 Region, defaults to us-east-1"""
+  -r, --region REGION        Amazon EC2 Region, defaults to us-east-1 or ENV[AWS_EC2_REGION]"""
 
 
 def list_instances():
@@ -72,7 +72,7 @@ def main(argv):
 
     aws_key = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    region = None
+    region = os.environ.get("AWS_EC2_REGION")
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):

--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -13,18 +13,19 @@ _ec2 = None
 
 
 def short_usage():
-    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [NAME]
+    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [NAME]
     ec2-host django8 => ec2-53-19-113-121.compute-1.amazonaws.com
 Try `ssh-distillery --help' for more information."""
 
 
 def full_usage():
-    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [NAME]
+    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [NAME]
 Prints server host name.
 
       --help                 display this help and exit
   -k, --aws-key KEY          Amazon EC2 Key, defaults to ENV[AWS_ACCESS_KEY_ID]
-  -s, --aws-secret SECRET    Amazon EC2 Secret, defaults to ENV[AWS_SECRET_ACCESS_KEY]"""
+  -s, --aws-secret SECRET    Amazon EC2 Secret, defaults to ENV[AWS_SECRET_ACCESS_KEY]
+  -r, --region REGION        Amazon EC2 Region, defaults to us-east-1"""
 
 
 def list_instances():

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -9,8 +9,10 @@ Usage: ec2-ssh [-k KEY] [-s SECRET] [-r REGION] <instance-name>
 Open an ssh connection to an EC2 instance where tag:Name=<instance-name>
 For list of instance, run ec2-host without any paramteres
 
--k, KEY       Amazon EC2 Key, defaults to \$AWS_ACCESS_KEY_ID
--s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
+  -h            display this help and exit
+  -k, KEY       Amazon EC2 Key, defaults to \$AWS_ACCESS_KEY_ID
+  -s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
+  -r, REGION    Amazon EC2 Region, defaults to us-east-1
 EOF
 }
 

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,16 +1,34 @@
-#!/bin/sh
-#/ Usage: ec2-ssh <instance-name>
-#/ Open ssh connection to EC2 instance where tag:Name=<instance-name>
-#/ For list of instance, run ec2-host without any paramteres
+#!/bin/bash
 
-set -e
+set -e 
 
-test $# -eq 0 -o $(expr "$*" : ".*--help") \
-				-ne 0 -o $(expr "$*" : ".*-h") -ne 0 && {
-    grep ^#/ < $0 |
-    cut -c4-
-    exit
+usage() {
+    cat<<EOF
+Usage: ec2-ssh [-k KEY] [-s SECRET] [-r REGION] <instance-name>
+
+Open an ssh connection to an EC2 instance where tag:Name=<instance-name>
+For list of instance, run ec2-host without any paramteres
+
+-k, KEY       Amazon EC2 Key, defaults to \$AWS_ACCESS_KEY_ID
+-s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
+EOF
 }
+
+# Print usage message and exit if no arguments are given
+test $# -eq 0 && { usage; exit; }
+
+# Process options
+cmd="ec2-host"
+while getopts ":hk:s:r:" opt; do
+    case $opt in
+        h  ) usage; exit 1;;
+        k  ) cmd="$cmd -k$OPTARG";;
+        s  ) cmd="$cmd -s$OPTARG";;
+        r  ) cmd="$cmd -r$OPTARG";;
+        \? ) usage; exit 1
+    esac
+done
+shift $((OPTIND - 1))
 
 # support user@instance-name format
 IFS="@"; declare -a hostparts=($1) 
@@ -18,13 +36,13 @@ IFS="@"; declare -a hostparts=($1)
 inst="${hostparts[1]}"
 user="${hostparts[0]}"
 
-if test -z "$inst"; then
-	inst="$1"
-	user="ubuntu"
+if [ -z "$inst" ]; then
+  inst="$1"
+  user="ubuntu"
 fi
 
 # get host from ec2-host command
-host=$(ec2-host $inst)
+host=$(exec sh -c "$cmd $inst")
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -6,13 +6,15 @@ usage() {
     cat<<EOF
 Usage: ec2-ssh [-k KEY] [-s SECRET] [-r REGION] <instance-name>
 
-Open an ssh connection to an EC2 instance where tag:Name=<instance-name>
-For list of instance, run ec2-host without any paramteres
+Open an ssh connection to an EC2 instance where <instance-name>=tag:value.
+The 'tag:' portion of <instance-name> is optional, and defaults to 'Name'.
+For a list of instances, run ec2-host without any paramteres
 
   -h            display this help and exit
   -k, KEY       Amazon EC2 Key, defaults to \$AWS_ACCESS_KEY_ID
   -s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
   -r, REGION    Amazon EC2 Region, defaults to us-east-1
+  -t, TAG       Tag name for searching, defaults to 'Name'
 EOF
 }
 
@@ -21,12 +23,13 @@ test $# -eq 0 && { usage; exit; }
 
 # Process options
 cmd="ec2-host"
-while getopts ":hk:s:r:" opt; do
+while getopts ":hk:s:r:t:" opt; do
     case $opt in
         h  ) usage; exit 1;;
-        k  ) cmd="$cmd -k$OPTARG";;
-        s  ) cmd="$cmd -s$OPTARG";;
-        r  ) cmd="$cmd -r$OPTARG";;
+        k  ) cmd="$cmd -k $OPTARG";;
+        s  ) cmd="$cmd -s $OPTARG";;
+        r  ) cmd="$cmd -r $OPTARG";;
+        t  ) cmd="$cmd -t $OPTARG";;
         \? ) usage; exit 1
     esac
 done
@@ -43,8 +46,20 @@ if [ -z "$inst" ]; then
   user="ubuntu"
 fi
 
+# support tag:value format for identifying instances
+IFS=":"; declare -a tagparts=($inst)
+
+tag="${tagparts[0]}"
+value="${tagparts[1]}"
+
+if [ -z "$value" ]; then
+    value="$inst"
+else
+    cmd="$cmd -t $tag"
+fi
+
 # get host from ec2-host command
-host=$(exec sh -c "$cmd $inst")
+host=$(exec sh -c "$cmd $value")
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e 
+set -e
 
 usage() {
     cat<<EOF
@@ -36,7 +36,7 @@ done
 shift $((OPTIND - 1))
 
 # support user@instance-name format
-IFS="@"; declare -a hostparts=($1) 
+IFS="@"; declare -a hostparts=($1)
 
 inst="${hostparts[1]}"
 user="${hostparts[0]}"
@@ -59,7 +59,7 @@ else
 fi
 
 # get host from ec2-host command
-host=$(exec sh -c "$cmd $value")
+host=$(eval "$cmd $inst")
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime


### PR DESCRIPTION
In this pull request (in addition to the four commits from #4) I've added support for specifying the tag that you wish to use to select the EC2 instance.

The way this works is as follows:

1) Running "ec2-host -t tag-name" will list all of the instances with value for the given tag
2) Running "ec2-host -t tag-name value" will list the instance that matches the tag=value criteria
3) Running "ec2-ssh -t tag-name value" will ssh into the instance matching the tag=value criteria
4) Running "ec2-ssh tag-name:value" is shorthand for (3)

The default if the tag option is left off is 'Name' and so, without this option, both scripts will continue to behave as they do now.
