### PR TITLE
Fix for running under zsh

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #/ Usage: ec2-ssh <instance-name>
 #/ Open ssh connection to EC2 instance where tag:Name=<instance-name>
 #/ For list of instance, run ec2-host without any paramteres


### PR DESCRIPTION
This script contains bashisms, and won't run under zsh for instance. You'll get an error something like /usr/local/bin/ec2-ssh: 16: Syntax error: "(" unexpected
