### PR TITLE
Honor existing $PS1 value.

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -63,7 +63,7 @@ host=$(eval "$cmd $inst")
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime
-cmd="echo \\\". ~/.bashrc && PS1='\[\e]0;$inst: \w\\\a\]\[\\\033[01;32m\]$inst\[\\\033[00m\]:\[\\\033[01;34m\]\w\[\\\033[00m\]\\\$ '\\\" > ~/.ec2sshrc; /bin/bash --rcfile .ec2sshrc -i"
+cmd="echo \\\". ~/.bashrc && PS1='\\\${PS1//\\\\\h/$inst}'\\\" > ~/.ec2sshrc; /bin/bash --rcfile .ec2sshrc -i"
 if test "${@:2}"; then
     cmd="${@:2}"
 fi


### PR DESCRIPTION
Replace `\h` with $inst in the user's existing PS1 variable, instead of replacing the contents entirely.
