### PR TITLE
patch to add support for VPC hosts

### DIFF
--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -43,6 +43,9 @@ def ec2_active_instances(label_tag, filters):
             if instance.public_dns_name:
                 pair = (instance_name, instance.public_dns_name)
                 instances.append(pair)
+            elif instance.vpc_id and instance.private_ip_address:
+                pair = (instance_name, instance.private_ip_address)
+                instances.append(pair)
     return instances
 
 

--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -60,7 +60,7 @@ def main(argv):
 
     aws_key = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    region = os.environ.get("AWS_EC2_REGION")
+    region = os.environ.get("AWS_EC2_REGION", "us-west-2")
     tag = "Name"
 
     for opt, arg in opts:


### PR DESCRIPTION
VPC hosts don't have a public DNS name, so they are not honored by the ec2-hosts script. This patch corrects this behavior and allows listing VPC hosts and SSH'ing into them by their private IP address.
