### PR TITLE
Introduce new options (default user, disable SSH security)

### DIFF
--- a/bin/ec2-host
+++ b/bin/ec2-host
@@ -19,14 +19,15 @@ Try `ec2-ssh --help' for more information."""
 
 
 def full_usage():
-    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [-t TAG] [NAME]
+    print >>stderr, """Usage: ec2-host [-k KEY] [-s SECRET] [-r REGION] [-t TAG] [-S sep] [NAME]
 Prints server host name.
 
       --help                 display this help and exit
   -k, --aws-key KEY          Amazon EC2 Key, defaults to ENV[AWS_ACCESS_KEY_ID]
   -s, --aws-secret SECRET    Amazon EC2 Secret, defaults to ENV[AWS_SECRET_ACCESS_KEY]
   -r, --region REGION        Amazon EC2 Region, defaults to us-east-1 or ENV[AWS_EC2_REGION]
-  -t, --tag TAG              Tag name for searching, defaults to 'Name'"""
+  -t, --tag TAG              Tag name for searching, defaults to 'Name'
+  -S, --separator SEP        Separator to use between hostname and dns"""
 
 
 def ec2_active_instances(label_tag, filters):
@@ -48,8 +49,8 @@ def ec2_active_instances(label_tag, filters):
 
 def main(argv):
     try:
-        opts, args = getopt.getopt(argv, "hLk:s:r:t:",
-                                         ["help", "aws-key=", "aws-secret=", "region=", "tag="])
+        opts, args = getopt.getopt(argv, "hLk:s:r:t:S:",
+                                         ["help", "aws-key=", "aws-secret=", "region=", "tag=", "separator="])
     except getopt.GetoptError, err:
         print >>sys.stderr, err
         short_usage()
@@ -59,6 +60,7 @@ def main(argv):
     aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
     region = os.environ.get("AWS_EC2_REGION")
     tag = "Name"
+    separator="\t"
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
@@ -72,6 +74,8 @@ def main(argv):
             region = arg
         elif opt in ("-t", "--tag"):
             tag = arg
+        elif opt in ("-S", "--separator"):
+            separator = arg
 
     if not aws_key or not aws_secret:
         if not aws_key:
@@ -115,7 +119,7 @@ def main(argv):
         return
     elif numinstances == 0 or numinstances > 1:
         for pair in sorted(instances, key=lambda p: p[0]):
-            print "%s\t%s" % pair
+            print "%s%s%s" % (pair[0], separator, pair[1])
 
         sys.exit(0)
         return

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -15,8 +15,7 @@ For a list of instances, run ec2-host without any paramteres
   -s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
   -r, REGION    Amazon EC2 Region, defaults to us-east-1
   -t, TAG       Tag name for searching, defaults to 'Name'
-  -u            Set default user to 'ubuntu' (eg. Ubuntu)
-  -a            Set default user to 'ec2-user' (eg. Amazon Linux)
+  -U, USER      Set default user to 'USER' (default 'ubuntu')
   -S            Disable SSH security (host key checks)
 EOF
 }
@@ -27,15 +26,14 @@ test $# -eq 0 && { usage; exit; }
 # Process options
 cmd="ec2-host"
 default_user="ubuntu"
-while getopts ":hk:s:r:t:auS" opt; do
+while getopts ":hk:s:r:t:U:S" opt; do
     case $opt in
         h  ) usage; exit 1;;
         k  ) cmd="$cmd -k $OPTARG";;
         s  ) cmd="$cmd -s $OPTARG";;
         r  ) cmd="$cmd -r $OPTARG";;
         t  ) cmd="$cmd -t $OPTARG";;
-        a  ) default_user="ec2-user";;
-        u  ) default_user="ubuntu";;
+        U  ) default_user="$OPTARG";;
         S  ) ssh_opts="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=false";;
         \? ) usage; exit 1
     esac

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -15,6 +15,9 @@ For a list of instances, run ec2-host without any paramteres
   -s, SECRET    Amazon EC2 Secret, defaults to \$AWS_SECRET_ACCESS_KEY
   -r, REGION    Amazon EC2 Region, defaults to us-east-1
   -t, TAG       Tag name for searching, defaults to 'Name'
+  -u            Set default user to 'ubuntu' (eg. Ubuntu)
+  -a            Set default user to 'ec2-user' (eg. Amazon Linux)
+  -S            Disable SSH security (host key checks)
 EOF
 }
 
@@ -23,13 +26,17 @@ test $# -eq 0 && { usage; exit; }
 
 # Process options
 cmd="ec2-host"
-while getopts ":hk:s:r:t:" opt; do
+default_user="ubuntu"
+while getopts ":hk:s:r:t:auS" opt; do
     case $opt in
         h  ) usage; exit 1;;
         k  ) cmd="$cmd -k $OPTARG";;
         s  ) cmd="$cmd -s $OPTARG";;
         r  ) cmd="$cmd -r $OPTARG";;
         t  ) cmd="$cmd -t $OPTARG";;
+        a  ) default_user="ec2-user";;
+        u  ) default_user="ubuntu";;
+        S  ) ssh_opts="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=false";;
         \? ) usage; exit 1
     esac
 done
@@ -43,7 +50,7 @@ user="${hostparts[0]}"
 
 if [ -z "$inst" ]; then
   inst="$1"
-  user="ubuntu"
+  user="$default_user"
 fi
 
 # support tag:value format for identifying instances
@@ -67,4 +74,4 @@ cmd="echo \\\". ~/.bashrc && PS1='\[\e]0;$inst: \w\\\a\]\[\\\033[01;32m\]$inst\[
 if test "${@:2}"; then
     cmd="${@:2}"
 fi
-test -n "$host" && echo "Connecting to $host." && exec sh -c "ssh -t $user@$host \"$cmd\""
+test -n "$host" && echo "Connecting to $host." && exec sh -c "ssh $ssh_opts -t $user@$host \"$cmd\""

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -59,7 +59,7 @@ else
 fi
 
 # get host from ec2-host command
-host=$(eval "$cmd $inst")
+host=$(eval "$cmd '$inst'")
 
 # pass all other parameters (${@:2}) to ssh allowing
 # things like: ec2-ssh nginx uptime

--- a/completion.bash
+++ b/completion.bash
@@ -1,0 +1,24 @@
+_ec2_ssh() {
+    local cur opts IFS
+    declare -a hosts
+
+    COMPREPLY=()
+    cur="${COMP_WORDS[$COMP_CWORD]}"
+
+    opts="-k -s -r -t"
+    if [ "${cur}" == "-" ]; then
+	COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+	return 0
+    fi
+
+    IFS=$'\n'
+    if [ "$cur" != "" ]; then
+	hosts=( $(ec2-host --separator ';' | cut -f1 -d';' | grep $cur) )
+    else
+	hosts=( $(ec2-host --separator ';' | cut -f1 -d';') )
+    fi
+    COMPREPLY=( $(printf '%q\n' "${hosts[@]}") )
+    return 0
+}
+
+complete -F _ec2_ssh ec2-ssh


### PR DESCRIPTION
This pull request adds 2 new features
1. -u/-a select the default ssh-user. This makes it more convenient for users of Amazon Linux. The default (ubuntu user) is unchanged.
2. -S disables ssh host key checks so the user does not need to confirm for new instances (or deal with changed host-keys).
